### PR TITLE
Add `UnsafeCellSlice::index_mut` and remove `UnsafeCellSlice::as_mut_slice`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,15 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@v2
+  miri_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+          components: miri
+      - name: Run tests (serial)
+        run: cargo +nightly miri test ser
+      - name: Run tests (parallel)
+        run: MIRIFLAGS="-Zmiri-ignore-leaks -Zmiri-tree-borrows" cargo +nightly miri test par

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        toolchain: ["stable", "1.60", "beta", "nightly"]
+        toolchain: ["stable", "1.63", "beta", "nightly"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
  - Change rust edition to 2021
+ - Bump MSRV to 1.63
 
 ### Removed
  - **Breaking**: Remove `UnsafeCellSlice::as_mut_slice` (potentially unsound)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
- - Add `UnsafeCellSlice::index_mut`
+ - Add `UnsafeCellSlice::index_mut()`
+ - Add `UnsafeCellSlice::len()` and `UnsafeCellSlice::is_empty()`
 
 ### Changed
  - Change rust edition to 2021
  - Bump MSRV to 1.63
 
 ### Removed
- - **Breaking**: Remove `UnsafeCellSlice::as_mut_slice` (potentially unsound)
+ - **Breaking**: Remove `UnsafeCellSlice::as_mut_slice()` (potentially unsound)
 
 ## [0.1.0] - 2024-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+ - Add `UnsafeCellSlice::index_mut`
+
 ### Changed
  - Change rust edition to 2021
+
+### Removed
+ - **Breaking**: Remove `UnsafeCellSlice::as_mut_slice` (potentially unsound)
 
 ## [0.1.0] - 2024-09-01
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "unsafe_cell_slice"
 version = "0.2.0"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.63"
 description = "A microlibrary for creating multiple mutable subslices of a slice"
 documentation = "https://docs.rs/unsafe_cell_slice"
 repository = "https://github.com/LDeakin/unsafe_cell_slice"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,15 @@
 [package]
 name = "unsafe_cell_slice"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.60"
-description = "A microlibrary for creating multiple mutable references to a slice"
+description = "A microlibrary for creating multiple mutable subslices of a slice"
 documentation = "https://docs.rs/unsafe_cell_slice"
 repository = "https://github.com/LDeakin/unsafe_cell_slice"
 license = "MIT OR Apache-2.0"
 keywords = ["slice", "unsafe", "unsafecell"]
 categories = ["rust-patterns"]
 exclude = [".github"]
+
+[dev-dependencies]
+rayon = "1.7.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,18 @@ impl<'a, T: Copy> UnsafeCellSlice<'a, T> {
         Self::new(unsafe { vec_spare_capacity_to_mut_slice(vec) })
     }
 
+    /// Return the length of the underlying slice.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Reutrn whether the underlying slice is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Get a mutable reference to a subslice of the underlying slice.
     ///
     /// Note that unlike [`std::ops::IndexMut::index_mut`], `self` is not a mutable reference.
@@ -80,13 +92,16 @@ impl<'a, T: Copy> UnsafeCellSlice<'a, T> {
     /// # Safety
     /// This is very unsafe because it is capable of creating multiple mutable references to the same data.
     /// It is the responsibility of the caller to only access non-overlapping subslices to avoid data races and undefined behavior.
-    /// 
+    ///
     /// # Panics
     /// May panic if the index is out of bounds.
     #[must_use]
     #[allow(clippy::mut_from_ref)]
     pub unsafe fn index_mut(&self, index: std::ops::Range<usize>) -> &mut [T] {
-        assert!(index.end <= self.len() && index.start <= index.end, "index out of bounds");
+        assert!(
+            index.end <= self.len() && index.start <= index.end,
+            "index out of bounds"
+        );
         let ptr = self.0[index.start].get();
         std::slice::from_raw_parts_mut(ptr, index.end - index.start)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,42 +1,42 @@
 //! # unsafe_cell_slice
 //!
-//! A Rust microlibrary for creating multiple mutable references to a [`slice`].
+//! A Rust microlibrary for creating multiple mutable subslices of a [`slice`].
 //!
 //! ### Motivation
-//! The rust borrow checker forbids creating multiple mutable references of a [`slice`].
+//! The rust borrow checker forbids creating multiple mutable subslices of a [`slice`].
 //! For example, this fails to compile with ```cannot borrow `data` as mutable more than once at a time```:
 //! ```rust,compile_fail
 //! let mut data = vec![0u8; 2];
-//! let data_a: &mut [u8] = data.as_mut_slice();
-//! let data_b: &mut [u8] = data.as_mut_slice();
+//! let data_a: &mut [u8] = &mut data[0..1];
+//! let data_b: &mut [u8] = &mut data[1..2];
 //! data_a[0] = 0;
-//! data_b[1] = 1;
+//! data_b[0] = 1;
 //! ```
 //!
-//! There are use cases for acquiring multiple mutable references to a [`slice`], such as for writing independent elements in parallel.
+//! There are use cases for acquiring multiple mutable subslices of a [`slice`], such as for writing independent elements in parallel.
 //! A safe approach is to borrow non-overlapping slices via [`slice::split_at_mut`], [`slice::chunks_mut`], etc.
 //! However, such approaches may not be applicable in complicated use cases, such as writing to interleaved elements.
 //!
 //! ### [`UnsafeCellSlice`]
 //! An [`UnsafeCellSlice`] can be created from a mutable slice or the spare capacity in a [`Vec`].
-//! It has an unsafe [`as_mut_slice`](UnsafeCellSlice::as_mut_slice) method that permits creating multiple mutable [`slice`] references.
+//! It has an unsafe [`index_mut`](UnsafeCellSlice::index_mut) method that permits creating multiple mutable subslices.
 //!
 //! ```rust
 //! # use unsafe_cell_slice::UnsafeCellSlice;
 //! let mut data = vec![0u8; 2];
 //! {
 //!     let data = UnsafeCellSlice::new(&mut data);
-//!     let data_a: &mut [u8] = unsafe { data.as_mut_slice() };
-//!     let data_b: &mut [u8] = unsafe { data.as_mut_slice() };
+//!     let data_a: &mut [u8] = unsafe { data.index_mut(0..1) };
+//!     let data_b: &mut [u8] = unsafe { data.index_mut(1..2) };
 //!     data_a[0] = 0;
-//!     data_b[1] = 1;
+//!     data_b[0] = 1;
 //! }
 //! assert_eq!(data[0], 0);
 //! assert_eq!(data[1], 1);
 //! ```
 //!
 //! Note that this is very unsafe and bypasses Rust's safety guarantees!
-//! It is the responsibility of the caller of [`UnsafeCellSlice::as_mut_slice()`] to avoid data races and undefined behavior.
+//! It is the responsibility of the caller of [`UnsafeCellSlice::index_mut()`] to avoid data races and undefined behavior by not requesting overlapping subslices.
 //!
 //! Under the hood, [`UnsafeCellSlice`] is a reference to a [`std::cell::UnsafeCell`] slice, hence the name of the crate.
 //!
@@ -47,9 +47,10 @@
 //!
 //! Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
 
-/// An unsafe cell slice. Permits acquisition of multiple mutable references to a slice.
+/// An unsafe cell slice. Permits acquisition of multiple mutable subslices of a slice.
 ///
-/// This is inherently unsafe and it is the responsibility of the caller to avoid data races and undefined behavior.
+/// This is inherently unsafe.
+/// It is the responsibility of the caller to only access non-overlapping subslices to avoid data races and undefined behavior.
 #[derive(Copy, Clone)]
 pub struct UnsafeCellSlice<'a, T>(&'a [std::cell::UnsafeCell<T>]);
 
@@ -71,17 +72,23 @@ impl<'a, T: Copy> UnsafeCellSlice<'a, T> {
         Self::new(unsafe { vec_spare_capacity_to_mut_slice(vec) })
     }
 
-    /// Get a mutable reference to the underlying slice.
+    /// Get a mutable reference to a subslice of the underlying slice.
+    ///
+    /// Note that unlike [`std::ops::IndexMut::index_mut`], `self` is not a mutable reference.
+    /// Thus, this method does not support desuraging.
     ///
     /// # Safety
-    /// This returns a mutable reference to the underlying slice despite `self` being a non-mutable reference.
-    /// This is unsafe because it can be called multiple times, thus creating multiple mutable references to the same data.
-    /// It is the responsibility of the caller to avoid data races and undefined behavior.
+    /// This is very unsafe because it is capable of creating multiple mutable references to the same data.
+    /// It is the responsibility of the caller to only access non-overlapping subslices to avoid data races and undefined behavior.
+    /// 
+    /// # Panics
+    /// May panic if the index is out of bounds.
     #[must_use]
     #[allow(clippy::mut_from_ref)]
-    pub unsafe fn as_mut_slice(&self) -> &mut [T] {
-        let ptr = self.0[0].get();
-        std::slice::from_raw_parts_mut(ptr, self.0.len())
+    pub unsafe fn index_mut(&self, index: std::ops::Range<usize>) -> &mut [T] {
+        assert!(index.end <= self.len() && index.start <= index.end, "index out of bounds");
+        let ptr = self.0[index.start].get();
+        std::slice::from_raw_parts_mut(ptr, index.end - index.start)
     }
 }
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,0 +1,13 @@
+pub const N_REPETITIONS: i64 = 1_000;
+
+pub fn decr(data: &mut i64) {
+    for _ in 0..N_REPETITIONS {
+        *data -= 1;
+    }
+}
+
+pub fn incr(data: &mut i64) {
+    for _ in 0..N_REPETITIONS {
+        *data += 1;
+    }
+}

--- a/tests/v0_1.rs
+++ b/tests/v0_1.rs
@@ -1,0 +1,35 @@
+// #[path = "common.rs"]
+// mod common;
+// use common::{decr, incr, N_REPETITIONS};
+
+// use unsafe_cell_slice::UnsafeCellSlice;
+
+// #[test]
+// fn smoke_test_ser_0_1() {
+//     let mut data = vec![0i64; 2];
+//     {
+//         let data = UnsafeCellSlice::new(&mut data);
+//         let data_a: &mut [i64] = unsafe { data.as_mut_slice() };
+//         let data_b: &mut [i64] = unsafe { data.as_mut_slice() };
+//         decr(&mut data_a[0]);
+//         incr(&mut data_b[1]);
+//         decr(&mut data_a[0]);
+//         incr(&mut data_b[1]);
+//     }
+//     assert_eq!(data[0], -2 * N_REPETITIONS);
+//     assert_eq!(data[1], 2 * N_REPETITIONS);
+// }
+
+// #[test]
+// fn smoke_test_par_0_1() {
+//     let mut data = vec![0i64; 2];
+//     {
+//         let data = UnsafeCellSlice::new(&mut data);
+//         let data_a: &mut [i64] = unsafe { data.as_mut_slice() };
+//         let data_b: &mut [i64] = unsafe { data.as_mut_slice() };
+//         rayon::join(|| decr(&mut data_a[0]), || incr(&mut data_b[1]));
+//         rayon::join(|| decr(&mut data_a[0]), || incr(&mut data_b[1]));
+//     }
+//     assert_eq!(data[0], -2 * N_REPETITIONS);
+//     assert_eq!(data[1], 2 * N_REPETITIONS);
+// }

--- a/tests/v0_2.rs
+++ b/tests/v0_2.rs
@@ -1,0 +1,35 @@
+#[path = "common.rs"]
+mod common;
+use common::{decr, incr, N_REPETITIONS};
+
+use unsafe_cell_slice::UnsafeCellSlice;
+
+#[test]
+fn smoke_test_ser_0_2() {
+    let mut data = vec![0i64; 2];
+    {
+        let data = UnsafeCellSlice::new(&mut data);
+        let data_a: &mut [i64] = unsafe { data.index_mut(0..1) };
+        let data_b: &mut [i64] = unsafe { data.index_mut(1..2) };
+        decr(&mut data_a[0]);
+        incr(&mut data_b[0]);
+        decr(&mut data_a[0]);
+        incr(&mut data_b[0]);
+    }
+    assert_eq!(data[0], -2 * N_REPETITIONS);
+    assert_eq!(data[1], 2 * N_REPETITIONS);
+}
+
+#[test]
+fn smoke_test_par_0_2_par() {
+    let mut data = vec![0i64; 2];
+    {
+        let data = UnsafeCellSlice::new(&mut data);
+        let data_a: &mut [i64] = unsafe { data.index_mut(0..1) };
+        let data_b: &mut [i64] = unsafe { data.index_mut(1..2) };
+        rayon::join(|| decr(&mut data_a[0]), || incr(&mut data_b[0]));
+        rayon::join(|| decr(&mut data_a[0]), || incr(&mut data_b[0]));
+    }
+    assert_eq!(data[0], -2 * N_REPETITIONS);
+    assert_eq!(data[1], 2 * N_REPETITIONS);
+}


### PR DESCRIPTION
This potentially addresses unsoundness noted in #1.